### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: yarn
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-- package-ecosystem: yarn
+- package-ecosystem: npm
   directory: "/"
   schedule:
     interval: monthly


### PR DESCRIPTION
add auto upgrade

about npm: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem

yarn and npm has the same value `npm`

I set it to run monthly. So there won't be too many pr.